### PR TITLE
Fingerprint production assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '3.8.4'
+gem 'jekyll', '3.8.5'
 
 group :jekyll_plugins do
-  gem 'jekyll-paginate'
-  gem 'jekyll-sitemap'
+  gem 'jekyll-paginate', '~> 1.1'
+  gem 'jekyll-sitemap', '~> 1.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.9.25)
+    ffi (1.10.0)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (3.8.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -32,25 +32,25 @@ GEM
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.1.2)
       listen (~> 3.0)
     kramdown (1.17.0)
-    liquid (4.0.0)
+    liquid (4.0.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.6.0)
+    safe_yaml (1.0.5)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -60,9 +60,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (= 3.8.4)
-  jekyll-paginate
-  jekyll-sitemap
+  jekyll (= 3.8.5)
+  jekyll-paginate (~> 1.1)
+  jekyll-sitemap (~> 1.2)
 
 BUNDLED WITH
-   1.16.1
+   2.0.1

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-site: Duet Jekyll Theme
+site: Michelle's Personal Website
 
 collections:
   pages:
@@ -41,7 +41,7 @@ markdown: kramdown
 kramdown:
   input: GFM
   syntax_highlighter: rouge
-  
+
 sass:
   style: compressed
 
@@ -59,4 +59,3 @@ grid_columns:
   two: Two
   three: Three
   four: Four
-  

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,8 +41,8 @@
 
 	<!-- Styles -->
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link rel="stylesheet" href="/css/style.css">
-	
+	<link rel="stylesheet" href="{{ '/css/style.css' | asset_fingerprint | absolute_url }}">
+
 	<!-- Icons -->
 	<script defer src="https://use.fontawesome.com/releases/v5.1.1/js/solid.js" integrity="sha384-GXi56ipjsBwAe6v5X4xSrVNXGOmpdJYZEEh/0/GqJ3JTHsfDsF8v0YQvZCJYAiGu" crossorigin="anonymous"></script>
 	<script defer src="https://use.fontawesome.com/releases/v5.1.1/js/brands.js" integrity="sha384-0inRy4HkP0hJ038ZyfQ4vLl+F4POKbqnaUB6ewmU4dWP0ki8Q27A0VFiVRIpscvL" crossorigin="anonymous"></script>
@@ -62,7 +62,7 @@
 	<!-- Extra Header JS Code -->
 	{{ site.data.settings.advanced_settings.header_js }}
 	{% endif %}
-	
+
 </head>
 
 
@@ -76,7 +76,7 @@
 
 	<div class="page-loader"></div>
 
-	
+
 	<div class="page">
 
 		<div class="page__content" data-page-title="{% if page.url == "/" %}{{ site.data.settings.basic_settings.site_title }} – {{ page.title }}{% else %}{{ page.title }} – {{ site.data.settings.basic_settings.site_title }}{% endif %}">
@@ -93,7 +93,7 @@
 
 	<!-- Javascript Assets -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-	<script src="/js/duet-min.js"></script>
+	<script src="{{ '/js/duet-min.js' | asset_fingerprint | absolute_url }}"></script>
 
 	{% if site.data.settings.advanced_settings.footer_js %}
 	<!-- Extra Footer JS Code -->

--- a/_plugins/asset_fingerprint.rb
+++ b/_plugins/asset_fingerprint.rb
@@ -1,0 +1,40 @@
+require 'digest'
+
+module Jekyll
+  # Jekyll assets asset_fingerprint filter
+  module AssetFingerprint
+    # Usage example:
+    #
+    # {{ "/style.css" | asset_fingerprint }}
+    # {{ "/style.css" | asset_fingerprint | absolute_url }}
+    def asset_fingerprint(relative_path)
+      if Jekyll.env == "production"
+        md5 = Digest::MD5.file(File.join(@context.registers[:site].dest, relative_path))
+        interpolate_digest(relative_path, md5.hexdigest)
+      else
+        relative_path
+      end
+    rescue => exception
+      puts exception
+      relative_path
+    end
+
+    def interpolate_digest(path, digest)
+      prefix, _, ext = path.rpartition('.')
+      "#{prefix}-#{digest}.#{ext}"
+    end
+    module_function :interpolate_digest
+
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::AssetFingerprint)
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  if Jekyll.env == "production"
+    Dir.glob("#{site.config['destination']}/**/*.{js,css}").each do |file|
+      md5 = Digest::MD5.file(file)
+      FileUtils.cp(file, Jekyll::AssetFingerprint.interpolate_digest(file, md5.hexdigest))
+    end
+  end
+end


### PR DESCRIPTION
Adds asset fingerprints to avoid cache issues  for js and css files when `JEKYLL_ENV=production` is set.

Can be used in templates to include fingerprint url: 

```
{{ 'filename.css' | asset_fingerprint }} => filename-d35fad588697bc4320f51cf33d2ce3b7.css
```