### PR TITLE
Fix blog link underline

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -15,7 +15,7 @@ menu_settings:
     - title: 'Reading'
       url: '/reading-list'
     - title: 'Blog'
-      url: '/blog'
+      url: '/blog/'
 
 footer_settings:
   logo_image:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,7 +38,7 @@
 						<img id="alice-3" src="/images/alice-3.png"/>
 					</li>
 					<li class="menu__list__item">
-						<a href="/blog" class="menu__list__item__link">Blog</a>
+						<a href="/blog/" class="menu__list__item__link">Blog</a>
 						<img id="alice-4" src="/images/alice-4.png"/>
 					</li>
 				</ul>


### PR DESCRIPTION
Match nav link with the blog page url (has a trailing slash)